### PR TITLE
feat: consider consuming passphrases from env optionally for non-interactive use

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -83,12 +83,16 @@ def patch_ota(
         '--rootless',
     ]
 
-    if pass_avb is not None:
-        cmd.append('--pass-avb-env-var')
-        cmd.append(pass_avb)
-    if pass_ota is not None:
-        cmd.append('--pass-ota-env-var')
-        cmd.append(pass_ota)
+    if pass_avb is None:
+        pass_avb = os.getenv('PASSPHRASE_AVB')
+        if pass_avb is not None:
+            cmd.append('--pass-avb-env-var')
+            cmd.append(pass_avb)
+    if pass_ota is None:
+        pass_ota = os.getenv('PASSPHRASE_OTA')
+        if pass_ota is not None:
+            cmd.append('--pass-ota-env-var')
+            cmd.append(pass_ota)
 
     for k, v in replace.items():
         cmd.append('--replace')

--- a/patch.py
+++ b/patch.py
@@ -83,6 +83,13 @@ def patch_ota(
         '--rootless',
     ]
 
+    if pass_avb is not None:
+        cmd.append('--pass-avb-env-var')
+        cmd.append(pass_avb)
+    if pass_ota is not None:
+        cmd.append('--pass-ota-env-var')
+        cmd.append(pass_ota)
+
     for k, v in replace.items():
         cmd.append('--replace')
         cmd.append(k)

--- a/patch.py
+++ b/patch.py
@@ -90,14 +90,14 @@ def patch_ota(
         cmd.append(pass_avb)
     elif pass_avb_file is not None:
         cmd.append('--pass-avb-file')
-        cmd.append(str(pass_avb_file))
+        cmd.append(Path(str(pass_avb_file)).read_text().strip())
 
     if pass_ota is not None:
         cmd.append('--pass-ota-env-var')
         cmd.append(pass_ota)
     elif pass_ota_file is not None:
         cmd.append('--pass-ota-file')
-        cmd.append(str(pass_ota_file))
+        cmd.append(Path(str(pass_ota_file)).read_text().strip())
 
     for k, v in replace.items():
         cmd.append('--replace')

--- a/patch.py
+++ b/patch.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import tempfile
 import tomlkit
-from typing import assert_never, Iterable, Match, Pattern, Tuple, Optional
+from typing import assert_never, Iterable, Match, Pattern, Tuple
 import zipfile
 
 
@@ -67,10 +67,10 @@ def patch_ota(
     key_ota: Path,
     cert_ota: Path,
     replace: dict[str, Path],
-    pass_avb: Optional[str] = None,
-    pass_ota: Optional[str] = None,
-    pass_avb_file: Optional[Path] = None,
-    pass_ota_file: Optional[Path] = None,
+    pass_avb: str | None = None,
+    pass_ota: str | None = None,
+    pass_avb_file: str | None = None,
+    pass_ota_file: str | None = None,
 ):
     image_names = ', '.join(sorted(replace.keys()))
     status(f'Patching OTA with replaced images: {image_names}: {output_ota}')
@@ -90,14 +90,14 @@ def patch_ota(
         cmd.append(pass_avb)
     elif pass_avb_file is not None:
         cmd.append('--pass-avb-file')
-        cmd.append(str(pass_avb_file))
+        cmd.append(pass_avb_file)
 
     if pass_ota is not None:
         cmd.append('--pass-ota-env-var')
         cmd.append(pass_ota)
     elif pass_ota_file is not None:
         cmd.append('--pass-ota-file')
-        cmd.append(str(pass_ota_file))
+        cmd.append(pass_ota_file)
 
     for k, v in replace.items():
         cmd.append('--replace')

--- a/patch.py
+++ b/patch.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import tempfile
 import tomlkit
-from typing import assert_never, Iterable, Match, Pattern, Tuple
+from typing import assert_never, Iterable, Match, Pattern, Tuple, Optional
 import zipfile
 
 
@@ -67,6 +67,8 @@ def patch_ota(
     key_ota: Path,
     cert_ota: Path,
     replace: dict[str, Path],
+    pass_avb: Optional[str] = None,
+    pass_ota: Optional[str] = None,
 ):
     image_names = ', '.join(sorted(replace.keys()))
     status(f'Patching OTA with replaced images: {image_names}: {output_ota}')

--- a/patch.py
+++ b/patch.py
@@ -846,6 +846,16 @@ def parse_args():
         action='store_true',
         help='Spawn a debug shell before cleaning up temporary directory',
     )
+    parser.add_argument(
+        '--pass-avb',
+        type=str,
+        help='Private key passphrase for AVB signing. If not passed, the user will be prompted for the passphrase.',
+    )
+    parser.add_argument(
+        '--pass-ota',
+        type=str,
+        help='Private key passphrase for OTA signing. If not passed, the user will be prompted for the passphrase.',
+    )
 
     args = parser.parse_args()
 
@@ -985,6 +995,8 @@ def run(args: argparse.Namespace, temp_dir: Path):
         args.sign_key_avb,
         args.sign_key_ota,
         args.sign_cert_ota,
+        args.pass_avb,
+        args.pass_ota,
         {
             'system': system_image,
             'vendor': vendor_image,

--- a/patch.py
+++ b/patch.py
@@ -90,14 +90,14 @@ def patch_ota(
         cmd.append(pass_avb)
     elif pass_avb_file is not None:
         cmd.append('--pass-avb-file')
-        cmd.append(Path(str(pass_avb_file)).read_text().strip())
+        cmd.append(str(pass_avb_file))
 
     if pass_ota is not None:
         cmd.append('--pass-ota-env-var')
         cmd.append(pass_ota)
     elif pass_ota_file is not None:
         cmd.append('--pass-ota-file')
-        cmd.append(Path(str(pass_ota_file)).read_text().strip())
+        cmd.append(str(pass_ota_file))
 
     for k, v in replace.items():
         cmd.append('--replace')


### PR DESCRIPTION
# Description

This PR makes use of `Optional` package from `typing` to optionally consider reading `pass_avb` and `pass_ota`.  

This is a very naive and insecure approach.  

Open for improvements if you wish to accept this change.