### PR TITLE
Declare python dependencies in requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ This repo includes the script I use for modifying Android OTAs. Folks should pro
 * Linux
     * Needed for running a statically-linked Android executable
 * python3
-* [python3-pydantic](https://pypi.org/project/pydantic/)
-* [python3-tomlkit](https://pypi.org/project/tomlkit/)
 * [avbroot](https://github.com/chenxiaolong/avbroot) (>= version 3.12.0)
 * [afsr](https://github.com/chenxiaolong/afsr) (>= commit adcae036b68684828edf5eb90be1500abd5cf491)
 * [Custota](https://github.com/chenxiaolong/Custota) (>= version 5.2)
@@ -26,6 +24,7 @@ The `avbroot`, `afsr`, and `custota-tool` commands must exist in `PATH`.
 ## Usage
 
 ```bash
+pip install -r requirements.txt
 python3 patch.py \
     --input ota.zip \
     --verify-public-key-avb verify_avb_pkmd.bin \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pydantic==2.10.6
+tomlkit==0.13.2


### PR DESCRIPTION
This makes it more deterministic and easier to install