### PR TITLE
Update pydantic for compatibility to python 3.14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pydantic==2.10.6
+pydantic==2.12.0
 tomlkit==0.13.2


### PR DESCRIPTION
Running patch.py with python 3.14.0 results in errors like

error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
= help: please check if an updated version of PyO3 is available. Current version: 0.22.6

See schnatterer/rooted-graphene#182 (especially schnatterer/rooted-graphene@f1943d267828d3ca5758b92a56f1a88be6e4092b) for details.